### PR TITLE
Allow upgrading dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.idea/
+/build/
+/vendor/
+/composer.lock
+/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "php-http/httplug": "1.1.*",
-    "guzzlehttp/psr7": "1.4.*"
+    "php-http/httplug": "^1.1 || ^2.0",
+    "guzzlehttp/psr7": "^1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.1",


### PR DESCRIPTION
The current composer.json configuration doesn't allow consumers of this package to update/upgrade their dependencies beyond the minor version required by this package.

According to semantic versioning (and after looking at the changelog of each dependency), I believe it should be safe to loosen the version constraints giving consumers the ability to upgrade their dependencies.